### PR TITLE
bouncer: error message when config file not found

### DIFF
--- a/bouncer.js
+++ b/bouncer.js
@@ -11,8 +11,13 @@ const reverse = require('util').promisify(dns.reverse);
 // Load jbnc.conf
 _config = process.argv[2]?process.argv[2]:"jbnc.conf";
 var config = {};
-if(fs.existsSync(_config)) config = JSON.parse(fs.readFileSync(_config));
-else process.exit(1);
+if(fs.existsSync(_config)) {
+  config = JSON.parse(fs.readFileSync(_config));
+}
+else {
+  console.error(`No config file found: ${_config}`);
+  process.exit(1);
+}
 
 // Set config vars
 var BOUNCER_PORT = config.bouncerPort?config.bouncerPort:8888;


### PR DESCRIPTION
Small change that adds an error message for when the config file isn't found. This is useful for users because otherwise the program ends without giving users any feedback as to what happened.