### PR TITLE
Error after the 22nd day : try to solve

### DIFF
--- a/bouncer.js
+++ b/bouncer.js
@@ -1139,7 +1139,7 @@ function clientConnect(socket) {
               }
               for(x=0;x<_names.length;x++) {
                 this.channels[_channel].names.push(_names[x].trim().split("!")[0]);
-                if(_names[x].trim().indexOf("!")>=0)
+                if(typeof this.channels[_channel].userhosts !== 'undefined' && _names[x].trim().indexOf("!")>=0)
                   this.channels[_channel].userhosts.push(_names[x].trim().split("!")[1]);
               }
               break;


### PR DESCRIPTION
TypeError: Cannot read property 'push' of undefined
    at TLSSocket.<anonymous> (/home/debian/node/jbnc/bouncer.js:1142:55)
    at TLSSocket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at TLSSocket.Readable.push (_stream_readable.js:212:10)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:186:23)

Maybe the raw 353 continues to play even though the user has left the channel or is logged out

For 25 days, there is an average of 100 connected simultaneous using Jbnc. The only errors found are often "undefined".