### PR TITLE
Fixed undefined in userhosts

### DIFF
--- a/bouncer.js
+++ b/bouncer.js
@@ -862,9 +862,18 @@ function clientConnect(socket) {
             continue;
           }
 
-          if(SASL && data[1]=="903") {
-            this.write("CAP END\n");
-            continue;
+          // :irc.server 904 <nick> :SASL authentication failed
+          if(data[1]=="904") {
+            if(!this.authenticated) {
+              this.end();
+            }
+          }
+
+          // :x 903 y :SASL authentication successful
+          if(data[1]=="903") {
+            if(!this.authenticated) {
+              this.write("CAP END\n");
+            }
           }
 		  
           let s = (data[2]=="JOIN" || data[2]=="PART" || data[2]=="QUIT" || data[2]=="MODE" || data[2]=="PING" || data[2]=="NICK" || data[2]=="KICK" ? data[2] : data[1]);
@@ -1251,7 +1260,7 @@ function clientConnect(socket) {
               }
               break;
           }
-		  if(data[1] == "PING") {
+          if(data[1] == "PING") {
             this.write("PONG "+data[2].substr(1).trim()+"\n");
             continue;
           }
@@ -1295,7 +1304,7 @@ function clientConnect(socket) {
         this.parents[x].end();
       }
       this.buffers=false;
-	  delete connections[hash(this.nick+this.password+this.server+this.port.toString())];
+      delete connections[hash(this.nick+this.password+this.server+this.port.toString())];
       this.destroy();
     });
     connection.on('error', function(err) {

--- a/bouncer.js
+++ b/bouncer.js
@@ -805,7 +805,7 @@ function clientConnect(socket) {
       }
       
       if (true) {
-        for(let n=0;n<lines.length;n++) {
+        for(n=0;n<lines.length;n++) {
           if(DEBUG)
             console.log("> "+lines[n]);
           data = lines[n].trim().split(" ");
@@ -1207,10 +1207,14 @@ function clientConnect(socket) {
               }
               for(x=0;x<_names.length;x++) {
                 this.channels[_channel].names.push(_names[x].trim().split("!")[0]);
-                if(typeof this.channels[_channel].userhosts !== 'undefined' && _names[x].trim().indexOf("!")>=0)
+
+                if (typeof this.channels[_channel].userhosts === 'undefined')
+                  this.channels[_channel].userhosts=[];
+
+                if(_names[x].trim().indexOf("!")>=0)
                   this.channels[_channel].userhosts.push(_names[x].trim().split("!")[1]);
-                  /*else
-					  this.channels[_channel].userhosts.push("*@*");	*/						
+                /*else
+                  this.channels[_channel].userhosts.push("*@*");	*/						
               }
               break;
             case '366':


### PR DESCRIPTION

Fixed this crash:

	/home/debian/node/jbnc/bouncer.js:1157
	this.channels[__channel].userhosts.push(this.userHostInNames?_userhost:"*@*");
	TypeError: Cannot read property 'push' of undefined



Reproduce the bug:
You just have to do a lot of join/part on the channel #+18ans old and after a while, it will crash on userhosts=>undefined



Added this code in raw 353:

	if (typeof this.channels[_channel].userhosts === 'undefined')
	this.channels[_channel].userhosts=[];


I flooded my join / part connection without crash
